### PR TITLE
v0.2.1

### DIFF
--- a/Sbnc.php
+++ b/Sbnc.php
@@ -5,7 +5,7 @@ namespace sbnc;
 // sbnc. Class must be included before headers have been sent.
 //
 // Simply remove the line below to disable buffering.
-// ob_start();
+ob_start();
 
 /**
  * Class Sbnc
@@ -197,7 +197,7 @@ class Sbnc
      */
     public static function printException(\Exception $e)
     {
-        // if (ob_get_level() > 0) ob_clean();
+        if (ob_get_level() > 0) ob_clean();
         $err = '<h3>Sorry, there was an error (sbnc)!</h3>';
         $err .= '<pre>';
         $err .= '<span style="font-weight:600">' . $e->getMessage() . '</span>';
@@ -206,7 +206,7 @@ class Sbnc
         $err .= $e->getTraceAsString();
         $err .= '</pre>';
         echo $err;
-        // if (ob_get_level() > 0) ob_end_flush();
+        if (ob_get_level() > 0) ob_end_flush();
         exit;
     }
 

--- a/Sbnc.php
+++ b/Sbnc.php
@@ -27,7 +27,7 @@ class Sbnc
     ######################################################################################
 
     /**
-     * CHANGE THIS VALUE ANF BEGIN IT WITH A LETTER!
+     * CHANGE THIS VALUE AND BEGIN IT WITH A LETTER!
      *
      * @var string
      */

--- a/Sbnc.php
+++ b/Sbnc.php
@@ -27,11 +27,11 @@ class Sbnc
     ######################################################################################
 
     /**
-     * CHANGE THIS VALUE AND BEGIN IT WITH A LETTER!
+     * This field name is used, if a session could not be created for storing a random one.
      *
      * @var string
      */
-    private static $prefix_field_name = 'kjb7A3f';
+    private static $fallback_prefix_field_name = 'kjb7A3f';
 
 
     /**
@@ -120,7 +120,10 @@ class Sbnc
      */
     public static function __callStatic($name, $params)
     {
-        self::init();
+        if (!self::$initialized) {
+            self::throwException('Sbnc was not initialized. Did you call Sbnc::start()?');
+        }
+
         try {
             return self::$core->call($name, $params);
         } catch (\Exception $e) {
@@ -152,6 +155,14 @@ class Sbnc
         self::$core->start($action);
     }
 
+    private static function startSession()
+    {
+        if (session_status() == PHP_SESSION_DISABLED) return false;
+        if (session_status() == PHP_SESSION_NONE && headers_sent()) return false;
+        if (session_status() != PHP_SESSION_ACTIVE && !session_start()) return false;
+        return true;
+    }
+
     /**
      * Load class autoloader, create core instance and initialize core
      */
@@ -159,17 +170,25 @@ class Sbnc
     {
         if (!self::$initialized) {
 
+            self::$initialized = true;
+
+            require_once __DIR__ . '/loader.php';
+
             $prefix_type = self::$options['prefix'];
-            $prefix_field = self::$prefix_field_name;
+            $prefix_field = self::$fallback_prefix_field_name;
+
+            if (self::startSession()) {
+                if (!helpers\Helpers::isPost()) {
+                    $_SESSION['sbnc_identifier'] = helpers\Helpers::randomKey(5, 8);
+                }
+                $prefix_field = $_SESSION['sbnc_identifier'];
+            }
 
             self::$options['prefix'] = [
                 'value' => $prefix_type,
                 'key' => $prefix_field
             ];
 
-            self::$initialized = true;
-
-            require_once __DIR__ . '/loader.php';
             self::$core = new core\Core([
                 'modules' => self::$modules,
                 'addons' => self::$addons,
@@ -181,7 +200,7 @@ class Sbnc
     }
 
     /**
-     * Throws and prints an exception
+     * Trigger an error
      *
      * @param $message String for Exception
      */

--- a/core/Core.php
+++ b/core/Core.php
@@ -155,6 +155,8 @@ class Core
                     }
                 } elseif (isset(self::$request['_sbnc_'.$first])) {
                     return self::$request['_sbnc_'.$first];
+                } elseif(isset(self::$request[$first])) {
+                    return self::$request[$first];
                 }
                 return null;
             case 'requestData':

--- a/core/Core.php
+++ b/core/Core.php
@@ -139,7 +139,7 @@ class Core
         }
 
         switch ($name) {
-            case 'errors';
+            case 'errors':
                 if (empty($params)) {
                     if (isset(self::$errors)) {
                         return self::$errors;
@@ -148,12 +148,17 @@ class Core
                     return self::$errors[$first];
                 }
                 return null;
-            case 'request';
+            case 'request':
                 if (empty($params)) {
                     if (isset(self::$request)) {
                         return self::$request;
                     }
-                } elseif (isset(self::$request[$first])) {
+                } elseif (isset(self::$request['_sbnc_'.$first])) {
+                    return self::$request['_sbnc_'.$first];
+                }
+                return null;
+            case 'requestData':
+                if (isset(self::$request[$first])) {
                     return self::$request[$first];
                 }
                 return null;
@@ -306,7 +311,7 @@ class Core
     private function initFields()
     {
         $this->addField(self::$options['prefix']['key'], self::$options['prefix']['value'], false);
-        $this->addField('url', Helpers::getUrl());
+        $this->addField('redirectUrl', base64_encode(Helpers::getUrl()));
     }
 
     /**
@@ -416,7 +421,7 @@ class Core
             if (!isset($flashed) && strcmp($decoded_key, $prefix_field) == 0) {
                 self::$options['prefix']['secret'] = $value;
             } elseif (strcmp(substr($key, 0, $random_prefix_length), $random_prefix) == 0) {
-                self::$request[substr($decoded_key, $random_prefix_length)] = $value;
+                self::$request['_sbnc_' . substr($decoded_key, $random_prefix_length)] = $value;
             } else {
                 self::$request[$key] = $value;
             }
@@ -485,7 +490,7 @@ class Core
             if ($this->utilExists('FlashMessages')) {
                 $this->getUtil('FlashMessages')->flash('core', 'redirected', true);
             }
-            header('Location: ' . Sbnc::request('url'));
+            header('Location: ' . base64_decode(Sbnc::request('redirectUrl')));
             exit;
         } else {
             $msg = 'Headers have already been sent. Make sure to include sbnc before any other output';

--- a/example.php
+++ b/example.php
@@ -1,7 +1,4 @@
 <?php
-error_reporting(E_ALL); // remove this line in production
-ini_set('display_errors', 'On'); // remove this line in production
-
 require 'Sbnc.php';
 use sbnc\Sbnc;
 
@@ -68,18 +65,5 @@ Sbnc::start($my_action); // or simply call Sbnc::start();
 </form>
 
 <?php Sbnc::printJavascript(); ?>
-
-<pre>
-<?php
-print_r($_SESSION);
-//unset($_SESSION['sbnc']);
-?>
-</pre>
-<br><br>
-<pre>
-<?php
-print_r(Sbnc::getLog());
-?>
-</pre>
 </body>
 </html>

--- a/example.php
+++ b/example.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL); // remove this line in production
+ini_set('display_errors', 'On'); // remove this line in production
 require 'Sbnc.php';
 use sbnc\Sbnc;
 

--- a/modules/Time.php
+++ b/modules/Time.php
@@ -59,13 +59,13 @@ class Time extends Module
 
     public function init()
     {
-        Sbnc::addField('time', time());
+        Sbnc::addField('time', base64_encode(time()));
     }
 
     public function check()
     {
         $now = time();
-        $time = Sbnc::request('time');
+        $time = base64_decode(Sbnc::request('time'));
         $diff = $now - $time;
 
         if (in_array('min', $this->use) && $diff < $this->options['min']) {

--- a/modules/Validate.php
+++ b/modules/Validate.php
@@ -111,7 +111,7 @@ class Validate extends Module
     {
         foreach ($this->validations as $key => $value) {
             foreach ($value as $validator) {
-                $val = Sbnc::request($key);
+                $val = Sbnc::requestData($key);
                 if ($val !== null) {
                     if (strcmp($validator, 'required') !== 0 && empty($val)) continue;
                     $data = explode(':', $validator);


### PR DESCRIPTION
### Changelog:
- The **field name** that holds the **prefix for other sbnc fields** is now **random**, if a session can be established. A configured fallback will be used instead.
- **Time and URL fields** are simply **base64 encoded**, to make them harder to detect (other encryption considered).
- **Sbnc fields** are **internally prefixed** with `_sbnc_`, so they can be distinguished from others, manually added to the markup. Sbnc data is retreived with `Sbnc::request()` as usual, other data should be fetched with `Sbnc::requestData()`. However, the `request()` method is backwards compatible.
